### PR TITLE
Check for (and don't use) Bashisms.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,5 @@ script:
   - STRAP_CI=1 STRAP_DEBUG=1 ./bin/strap.sh
   - brew install --build-from-source etl
   - brew cask install flux
+  - brew install checkbashisms
+  - checkbashisms --posix --force --extra ./bin/strap.sh


### PR DESCRIPTION
Even although Strap is hardcoded to use `/bin/bash` I think it's a bit nicer to not rely on Bashisms so people can extract(/copy-paste) bits elsewhere and have them work regardless of their shell of choice.