### PR TITLE
strap.sh: fix Homebrew permission issues.

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -95,9 +95,10 @@ HOMEBREW_PREFIX="/usr/local"
 HOMEBREW_CACHE="/Library/Caches/Homebrew"
 for dir in "$HOMEBREW_PREFIX" "$HOMEBREW_CACHE"; do
   [ -d "$dir" ] || sudo mkdir -p "$dir"
-  sudo chmod g+rwx "$dir"
+  sudo chmod -R g+rwx "$dir"
 done
-sudo chown root:admin "$HOMEBREW_PREFIX"
+sudo chgrp -R admin "$HOMEBREW_PREFIX" "$HOMEBREW_CACHE"
+sudo chown root "$HOMEBREW_PREFIX"
 
 # Download Homebrew.
 export GIT_DIR="$HOMEBREW_PREFIX/.git" GIT_WORK_TREE="$HOMEBREW_PREFIX"


### PR DESCRIPTION
Sometimes people may have `/usr/local` permissions that require a bit more manual coaxing to work.

CC @dice