### PR TITLE
Run security operations first.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 Strap is a script to bootstrap a minimal OS X development system. This does not assume you're doing Ruby/Rails/web development but installs the minimal set of software every OS X developer will want.
 
 ## Features
+- Disables Java in Safari (for better security)
+- Enables the OS X screensaver password immediately (for better security)
+- Enables the OS X application firewall (for better security)
+- Adds a `Found this computer?` message to the login screen (for machine recovery)
+- Enables full-disk encryption and saves the FileVault Recovery Key to the Desktop (for better security)
 - Installs the Xcode Command Line Tools (for compilers and Unix tools)
 - Agree to the Xcode license (for using compilers without prompts)
 - Installs [Homebrew](http://brew.sh) (for installing command-line software)
@@ -10,13 +15,8 @@ Strap is a script to bootstrap a minimal OS X development system. This does not 
 - Installs [Homebrew Services](https://github.com/Homebrew/homebrew-services) (for managing Homebrew-installed services)
 - Installs [Homebrew Cask](https://github.com/caskroom/homebrew-cask) (for installing graphical software)
 - Forwards `localhost` port `80` to `8080` and `443` to `8443` (for running web servers as an unprivileged user)
-- Disables Java in Safari (for better security)
-- Enables the OS X screensaver password immediately (for better security)
-- Enables the OS X application firewall (for better security)
-- Adds a `Found this computer?` message to the login screen (for machine recovery)
-- Enables full-disk encryption and saves the FileVault Recovery Key to the Desktop (for better security)
 - Installs the latest OS X software updates (for better security)
-- A simple web application to set Git's name, email and GitHub token.
+- A simple web application to set Git's name, email and GitHub token
 
 ## Usage
 Open https://osx-strap.herokuapp.com in your web browser.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Strap is a script to bootstrap a minimal OS X development system. This does not 
 - Forwards `localhost` port `80` to `8080` and `443` to `8443` (for running web servers as an unprivileged user)
 - Installs the latest OS X software updates (for better security)
 - A simple web application to set Git's name, email and GitHub token
+- Mostly idempotent (the slow bit is rerunning `brew update`)
 
 ## Usage
 Open https://osx-strap.herokuapp.com in your web browser.


### PR DESCRIPTION
They don’t rely on other operations having run and it’s nice to have them enabled even if the script fails later and people give up on it.

Also: note idempotency.