### PR TITLE
Gets `.Brewfile` from github and run brew bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Strap is a script to bootstrap a minimal OS X development system. This does not 
 - Installs [Homebrew Bundle](https://github.com/Homebrew/homebrew-bundle) (for `bundler`-like `Brewfile` support)
 - Installs [Homebrew Services](https://github.com/Homebrew/homebrew-services) (for managing Homebrew-installed services)
 - Installs [Homebrew Cask](https://github.com/caskroom/homebrew-cask) (for installing graphical software)
+- Gets a `.Brewfile` from users github repo `homebrew-brewfile` and put it at `$HOME` then run `brew bundle --global` to install those dependencies
 - Forwards `localhost` port `80` to `8080` and `443` to `8443` (for running web servers as an unprivileged user)
 - Installs the latest OS X software updates (for better security)
 - A simple web application to set Git's name, email and GitHub token

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Strap is a script to bootstrap a minimal OS X development system. This does not 
 - Installs [Homebrew Bundle](https://github.com/Homebrew/homebrew-bundle) (for `bundler`-like `Brewfile` support)
 - Installs [Homebrew Services](https://github.com/Homebrew/homebrew-services) (for managing Homebrew-installed services)
 - Installs [Homebrew Cask](https://github.com/caskroom/homebrew-cask) (for installing graphical software)
-- Gets a `.Brewfile` from users github repo `homebrew-brewfile` and put it at `$HOME` then run `brew bundle --global` to install those dependencies
 - Forwards `localhost` port `80` to `8080` and `443` to `8443` (for running web servers as an unprivileged user)
 - Installs the latest OS X software updates (for better security)
+- Installs software from a users `Brewfile` in their `https://github.com/username/homebrew-brewfile` repository.
 - A simple web application to set Git's name, email and GitHub token
 - Mostly idempotent (the slow bit is rerunning `brew update`)
 

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -248,6 +248,7 @@ sudo -k
 if [ -d ~/.homebrew-brewfile ]; then
   logn "Updating user Brewfile from GitHub:"
   cd ~/.homebrew-brewfile; git pull
+  logk
 else
   logn "Cloning user Brewfile from GitHub:"
   REPO_URL="https://github.com/$STRAP_GITHUB_USER/homebrew-brewfile"
@@ -261,9 +262,9 @@ else
 fi
 
 # Symlink .Brewfile
-if [ ! -s ~/.Brewfile ]; then
+if [ -f ~/.homebrew-brewfile/.Brewfile ]; then
   logn "Symlinking user Brewfile from ~/.homebrew-brewfile/.Brewfile to ~/.Brewfile:"
-  ln -s ~/.homebrew-brewfile/.Brewfile ~/.Brewfile
+  ln -sf ~/.homebrew-brewfile/.Brewfile ~/.Brewfile
   logk
 fi
 

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -251,24 +251,20 @@ if [ -d ~/.homebrew-brewfile ]; then
 else
   logn "Cloning user Brewfile from GitHub:"
   REPO_URL="https://github.com/$STRAP_GITHUB_USER/homebrew-brewfile"
-  STATUS_CODE=$(curl --silent --write-out "%{http_code}" --output /dev/null $REPO_URL)
+  STATUS_CODE=$(curl --silent --write-out "%{http_code}" --output /dev/null $REPO_URL/blob/master/.Brewfile)
   if [ "$STATUS_CODE" -eq 200 ]; then
      git clone $REPO_URL ~/.homebrew-brewfile
      logk
   else
-     echo "repo not found"
+     echo "not found"
   fi
 fi
 
 # Symlink .Brewfile
 if [ ! -s ~/.Brewfile ]; then
   logn "Symlinking user Brewfile from ~/.homebrew-brewfile/.Brewfile to ~/.Brewfile:"
-  if [ -f ~/.homebrew-brewfile/.Brewfile ]; then
-    ln -s ~/.homebrew-brewfile/.Brewfile ~/.Brewfile
-    logk
-  else
-    echo "not found"
-  fi
+  ln -s ~/.homebrew-brewfile/.Brewfile ~/.Brewfile
+  logk
 fi
 
 # Install global dependencies

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -256,8 +256,12 @@ fi
 # Symlink .Brewfile
 if [ ! -s $HOME/.Brewfile ]; then
   logn "Symlinking ~/.homebrew-brewfile/.Brewfile to ~/homebrew-brewfile/.Brewfile:"
-  ln -s $HOME/.homebrew-brewfile/.Brewfile $HOME/.Brewfile
-  logk
+  if [ -f $HOME/.homebrew-brewfile/.Brewfile ]; then
+    ln -s $HOME/.homebrew-brewfile/.Brewfile $HOME/.Brewfile
+    logk
+  else
+    echo "not found"
+  fi
 fi
 
 # Install global dependencies

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -245,24 +245,23 @@ fi
 sudo -k
 
 # Get remote Brewfile
-if [ -d ~/.homebrew-brewfile ]; then
+if [ -d "~/.homebrew-brewfile" ]; then
   logn "Updating user Brewfile from GitHub:"
-  cd ~/.homebrew-brewfile; git pull
+  cd ~/.homebrew-brewfile
+  git pull -q
   logk
 else
   logn "Cloning user Brewfile from GitHub:"
   REPO_URL="https://github.com/$STRAP_GITHUB_USER/homebrew-brewfile"
-  STATUS_CODE=$(curl --silent --write-out "%{http_code}" --output /dev/null $REPO_URL/blob/master/.Brewfile)
+  STATUS_CODE=$(curl --silent --write-out "%{http_code}" --output /dev/null $REPO_URL/blob/HEAD/.Brewfile)
   if [ "$STATUS_CODE" -eq 200 ]; then
-     git clone $REPO_URL ~/.homebrew-brewfile
-     logk
-  else
-     echo "not found"
+    git clone -q $REPO_URL ~/.homebrew-brewfile
+    logk
   fi
 fi
 
 # Symlink .Brewfile
-if [ -f ~/.homebrew-brewfile/.Brewfile ]; then
+if [ -f "~/.homebrew-brewfile/.Brewfile" ]; then
   logn "Symlinking user Brewfile from ~/.homebrew-brewfile/.Brewfile to ~/.Brewfile:"
   ln -sf ~/.homebrew-brewfile/.Brewfile ~/.Brewfile
   logk
@@ -270,8 +269,8 @@ fi
 
 # Install global dependencies
 logn "Installing from user Brewfile:"
-if [ -f $HOME/.Brewfile ]; then
-  echo ""
+if [ -f "~/.Brewfile" ]; then
+  log ""
   brew bundle --global
   logk
 else

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -244,37 +244,42 @@ fi
 # Revoke sudo access again.
 sudo -k
 
-# Get remote Brewfile
-if [ -d "~/.homebrew-brewfile" ]; then
-  logn "Updating user Brewfile from GitHub:"
-  cd ~/.homebrew-brewfile
-  git pull -q
-  logk
-else
-  logn "Cloning user Brewfile from GitHub:"
-  REPO_URL="https://github.com/$STRAP_GITHUB_USER/homebrew-brewfile"
-  STATUS_CODE=$(curl --silent --write-out "%{http_code}" --output /dev/null $REPO_URL/blob/HEAD/.Brewfile)
-  if [ "$STATUS_CODE" -eq 200 ]; then
-    git clone -q $REPO_URL ~/.homebrew-brewfile
+# User brewfile
+if [ -n "$STRAP_GITHUB_USER" ]; then
+
+  # Get remote Brewfile
+  if [ ! -d "$HOME/.homebrew-brewfile" ]; then
+    REPO_URL="https://github.com/$STRAP_GITHUB_USER/homebrew-brewfile"
+    STATUS_CODE=$(curl --silent --write-out "%{http_code}" --output /dev/null $REPO_URL/blob/HEAD/.Brewfile)
+    if [ "$STATUS_CODE" -eq 200 ]; then
+      logn "Cloning user Brewfile from GitHub:"
+      git clone -q $REPO_URL ~/.homebrew-brewfile
+      logk
+
+    fi
+  else
+    logn "Updating user Brewfile from GitHub:"
+    cd ~/.homebrew-brewfile
+    git pull -q
     logk
   fi
-fi
 
-# Symlink .Brewfile
-if [ -f "~/.homebrew-brewfile/.Brewfile" ]; then
-  logn "Symlinking user Brewfile from ~/.homebrew-brewfile/.Brewfile to ~/.Brewfile:"
-  ln -sf ~/.homebrew-brewfile/.Brewfile ~/.Brewfile
-  logk
-fi
+  # Symlink .Brewfile
+  if [ -f "$HOME/.homebrew-brewfile/.Brewfile" ]; then
+    logn "Symlinking user Brewfile from ~/.homebrew-brewfile/.Brewfile to ~/.Brewfile:"
+    ln -sf ~/.homebrew-brewfile/.Brewfile ~/.Brewfile
+    logk
+  fi
 
-# Install global dependencies
-logn "Installing from user Brewfile:"
-if [ -f "~/.Brewfile" ]; then
-  log ""
-  brew bundle --global
-  logk
-else
-  echo "skipped"
+  # Install user brewfile
+  logn "Installing from user Brewfile:"
+  if [ -f "$HOME/.Brewfile" ]; then
+    log ""
+    brew bundle --global
+    logk
+  else
+    echo "skipped"
+  fi
 fi
 
 STRAP_SUCCESS="1"

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -244,41 +244,21 @@ fi
 # Revoke sudo access again.
 sudo -k
 
-# User brewfile
+# Install from user brewfile
 if [ -n "$STRAP_GITHUB_USER" ]; then
-
-  # Get remote Brewfile
-  if [ ! -d "$HOME/.homebrew-brewfile" ]; then
-    REPO_URL="https://github.com/$STRAP_GITHUB_USER/homebrew-brewfile"
-    STATUS_CODE=$(curl --silent --write-out "%{http_code}" --output /dev/null $REPO_URL/blob/HEAD/.Brewfile)
-    if [ "$STATUS_CODE" -eq 200 ]; then
-      logn "Cloning user Brewfile from GitHub:"
-      git clone -q $REPO_URL ~/.homebrew-brewfile
-      logk
-
+  REPO_URL="https://github.com/$STRAP_GITHUB_USER/homebrew-brewfile"
+  STATUS_CODE=$(curl --silent --write-out "%{http_code}" --output /dev/null $REPO_URL/blob/HEAD/.Brewfile)
+  if [ "$STATUS_CODE" -eq 200 ]; then
+    logn "Installing from user Brewfile on GitHub:"
+    if [ ! -d "$HOME/.homebrew-brewfile" ]; then
+      git clone $Q $REPO_URL ~/.homebrew-brewfile
+    else
+      cd ~/.homebrew-brewfile
+      git pull $Q
     fi
-  else
-    logn "Updating user Brewfile from GitHub:"
-    cd ~/.homebrew-brewfile
-    git pull -q
-    logk
-  fi
-
-  # Symlink .Brewfile
-  if [ -f "$HOME/.homebrew-brewfile/.Brewfile" ]; then
-    logn "Symlinking user Brewfile from ~/.homebrew-brewfile/.Brewfile to ~/.Brewfile:"
     ln -sf ~/.homebrew-brewfile/.Brewfile ~/.Brewfile
-    logk
-  fi
-
-  # Install user brewfile
-  logn "Installing from user Brewfile:"
-  if [ -f "$HOME/.Brewfile" ]; then
-    log ""
     brew bundle --global
     logk
-  else
-    echo "skipped"
   fi
 fi
 

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -250,7 +250,14 @@ if [ -d ~/.homebrew-brewfile ]; then
   cd ~/.homebrew-brewfile; git pull
 else
   logn "Cloning user Brewfile from GitHub:"
-  git clone https://github.com/$STRAP_GITHUB_USER/homebrew-brewfile ~/.homebrew-brewfile
+  REPO_URL="https://github.com/$STRAP_GITHUB_USER/homebrew-brewfile"
+  STATUS_CODE=$(curl --silent --write-out "%{http_code}" --output /dev/null $REPO_URL)
+  if [ "$STATUS_CODE" -eq 200 ]; then
+     git clone $REPO_URL ~/.homebrew-brewfile
+     logk
+  else
+     echo "repo not found"
+  fi
 fi
 
 # Symlink .Brewfile

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -245,19 +245,19 @@ fi
 sudo -k
 
 # Get remote Brewfile
-if [ -d $HOME/.homebrew-brewfile ]; then
-  logn "Updating homebrew-brewfile from github:"
-  cd $HOME/.homebrew-brewfile; git pull
+if [ -d ~/.homebrew-brewfile ]; then
+  logn "Updating user Brewfile from GitHub:"
+  cd ~/.homebrew-brewfile; git pull
 else
-  logn
+  logn "Cloning user Brewfile from GitHub:"
   git clone https://github.com/$STRAP_GITHUB_USER/homebrew-brewfile ~/.homebrew-brewfile
 fi
 
 # Symlink .Brewfile
-if [ ! -s $HOME/.Brewfile ]; then
-  logn "Symlinking ~/.homebrew-brewfile/.Brewfile to ~/homebrew-brewfile/.Brewfile:"
-  if [ -f $HOME/.homebrew-brewfile/.Brewfile ]; then
-    ln -s $HOME/.homebrew-brewfile/.Brewfile $HOME/.Brewfile
+if [ ! -s ~/.Brewfile ]; then
+  logn "Symlinking user Brewfile from ~/.homebrew-brewfile/.Brewfile to ~/.Brewfile:"
+  if [ -f ~/.homebrew-brewfile/.Brewfile ]; then
+    ln -s ~/.homebrew-brewfile/.Brewfile ~/.Brewfile
     logk
   else
     echo "not found"
@@ -265,7 +265,7 @@ if [ ! -s $HOME/.Brewfile ]; then
 fi
 
 # Install global dependencies
-logn "Installing global Homebrew bundle:"
+logn "Installing from user Brewfile:"
 if [ -f $HOME/.Brewfile ]; then
   echo ""
   brew bundle --global


### PR DESCRIPTION
The idea is to add support for custom brew packages.

It should download the `Brewfile` from users `homebrew-brewfile` and then run `brew bundle --global`

I still think that is a good place for organization defaults.. but maybe we can discuss that in a separe issue.

 closes #21