### PR TITLE
Squelch git 2.x warning message on `git push`

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -153,6 +153,11 @@ if [ -n "$STRAP_GIT_EMAIL" ] && ! git config user.email >/dev/null; then
   git config --global user.email "$STRAP_GIT_EMAIL"
 fi
 
+# Squelch git 2.x warning message when pushing
+if ! git config push.default >/dev/null; then
+  git config --global push.default simple
+fi
+
 if [ -n "$STRAP_GITHUB_USER" ] && [ -n "$STRAP_GITHUB_TOKEN" ] \
   && git credential-osxkeychain 2>&1 | grep $Q "git.credential-osxkeychain"
 then


### PR DESCRIPTION
If no `push.default` setting exists, git outputs a massive warning message on each `git push` because the defaults have changed since git 1.x. This explicitly opts into git 2.x behavior which is the default.

The default git version on El Capitan is 2.4, while Homebrew installs 2.6.

I feel that this belongs to Strap because it's supposed to get you ready for `git push`in'. Well, it does, but you also get a massive warning on stderr, which doesn't feel very nice:

```
warning: push.default is unset; its implicit value has changed in
Git 2.0 from 'matching' to 'simple'. To squelch this message
and maintain the traditional behavior, use:

  git config --global push.default matching

To squelch this message and adopt the new behavior now, use:

  git config --global push.default simple

When push.default is set to 'matching', git will push local branches
to the remote branches that already exist with the same name.

Since Git 2.0, Git defaults to the more conservative 'simple'
behavior, which only pushes the current branch to the corresponding
remote branch that 'git pull' uses to update the current branch.

See 'git help config' and search for 'push.default' for further information.
(the 'simple' mode was introduced in Git 1.7.11. Use the similar mode
'current' instead of 'simple' if you sometimes use older versions of Git)
```
