### PR TITLE
Read homebrew-brewfile/Brewfile from API

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -274,7 +274,9 @@ fi
 
 if [ -n "$STRAP_GITHUB_USER" ]; then
   REPO_URL="https://github.com/$STRAP_GITHUB_USER/homebrew-brewfile"
-  STATUS_CODE=$(curl --silent --write-out "%{http_code}" --output /dev/null $REPO_URL/blob/HEAD/Brewfile)
+  REPO_API_URL="https://api.github.com/repos/$STRAP_GITHUB_USER/homebrew-brewfile"
+  STATUS_CODE=$(curl -u $STRAP_GITHUB_USER:$STRAP_GITHUB_TOKEN --silent --write-out "%{http_code}" --output /dev/null $REPO_API_URL/contents/Brewfile)
+
   if [ "$STATUS_CODE" -eq 200 ]; then
     logn "Fetching user Brewfile from GitHub:"
     if [ ! -d "$HOME/.homebrew-brewfile" ]; then

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -275,7 +275,7 @@ fi
 if [ -n "$STRAP_GITHUB_USER" ]; then
   REPO_URL="https://github.com/$STRAP_GITHUB_USER/homebrew-brewfile"
   REPO_API_URL="https://api.github.com/repos/$STRAP_GITHUB_USER/homebrew-brewfile"
-  STATUS_CODE=$(curl -u $STRAP_GITHUB_USER:$STRAP_GITHUB_TOKEN --silent --write-out "%{http_code}" --output /dev/null $REPO_API_URL/contents/Brewfile)
+  STATUS_CODE=$(curl -u "$STRAP_GITHUB_USER:$STRAP_GITHUB_TOKEN" --silent --write-out "%{http_code}" --output /dev/null $REPO_API_URL/contents/Brewfile)
 
   if [ "$STATUS_CODE" -eq 200 ]; then
     logn "Fetching user Brewfile from GitHub:"


### PR DESCRIPTION
Use the GitHub API to read the homebrew-brewfile/Brewfile to to allow access to private repositories.