### PR TITLE
Always install the Xcode CLT.

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -117,9 +117,10 @@ else
   abort "Run 'sudo fdesetup enable -user \"$USER\"' to enable full-disk encryption."
 fi
 
-# Install the Xcode Command Line Tools if Xcode isn't installed.
+# Install the Xcode Command Line Tools.
 DEVELOPER_DIR=$("xcode-select" -print-path 2>/dev/null || true)
-[ -z "$DEVELOPER_DIR" ] || ! [ -f "$DEVELOPER_DIR/usr/bin/git" ] && {
+[ -z "$DEVELOPER_DIR" ] || ! [ -f "$DEVELOPER_DIR/usr/bin/git" ] \
+                        || ! [ -f "/usr/include/iconv.h" ] && {
   log "Installing the Xcode Command Line Tools:"
   CLT_PLACEHOLDER="/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress"
   sudo touch "$CLT_PLACEHOLDER"
@@ -128,6 +129,16 @@ DEVELOPER_DIR=$("xcode-select" -print-path 2>/dev/null || true)
                 awk -F"*" '/^ +\*/ {print $2}' | sed 's/^ *//' | head -n1)
   sudo softwareupdate -i "$CLT_PACKAGE"
   sudo rm -f "$CLT_PLACEHOLDER"
+  if ! [ -f "/usr/include/iconv.h" ]; then
+    if [ -n "$STRAP_INTERACTIVE" ]; then
+      echo
+      logn "Requesting user install of Xcode Command Line Tools:"
+      xcode-select --install
+    else
+      echo
+      abort "Run 'xcode-select --install' to install the Xcode Command Line Tools."
+    fi
+  fi
   logk
 }
 


### PR DESCRIPTION
Even if Xcode is installed. Also, check for the presence of a header they install to double-check that they are definitely installed correctly (as it seems OS X updates could mess up with the previous check) and fall back to `xcode-select --install` when needed.

CC @jgkite