### PR TITLE
Try harder to fetch Homebrew.

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -204,7 +204,8 @@ export GIT_DIR="$HOMEBREW_PREFIX/.git" GIT_WORK_TREE="$HOMEBREW_PREFIX"
 git init $Q
 git config remote.origin.url "https://github.com/Homebrew/brew"
 git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-git fetch $Q origin master:refs/remotes/origin/master --no-tags --depth=1
+git fetch $Q origin master:refs/remotes/origin/master \
+  --no-tags --depth=1 --force --update-shallow
 git reset $Q --hard origin/master
 sudo chmod g+rwx "$HOMEBREW_PREFIX"/* "$HOMEBREW_PREFIX"/.??*
 unset GIT_DIR GIT_WORK_TREE


### PR DESCRIPTION
Be willing to update shallow repositories and handle remote history rewriting (i.e. the Homebrew repository migration).