### PR TITLE
specify full path for groups in case of coreutils

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -67,7 +67,7 @@ sw_vers -productVersion | grep $Q -E "^10.(9|10|11)" || {
 }
 
 [ "$USER" = "root" ] && abort "Run Strap as yourself, not root."
-groups | grep $Q admin || abort "Add $USER to the admin group."
+/usr/bin/groups | grep $Q admin || abort "Add $USER to the admin group."
 
 # Initialise sudo now to save prompting later.
 log "Enter your password (for sudo access):"


### PR DESCRIPTION
if coreutils gnubin is in PATH, `groups` command may fail to run (as it does on my machine)