### PR TITLE
strap.sh: tweak Git credential helper handling.

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -176,17 +176,20 @@ if ! git config push.default >/dev/null; then
 fi
 
 # Setup GitHub HTTPS credentials.
-if [ -n "$STRAP_GITHUB_USER" ] && [ -n "$STRAP_GITHUB_TOKEN" ] \
-  && git credential-osxkeychain 2>&1 | grep $Q "git.credential-osxkeychain"
+if git credential-osxkeychain 2>&1 | grep $Q "git.credential-osxkeychain"
 then
-  if [ "$(git config credential.helper)" != "osxkeychain" ]
+  if [ "$(git config --global credential.helper)" != "osxkeychain" ]
   then
     git config --global credential.helper osxkeychain
   fi
-  printf "protocol=https\nhost=github.com\n" | git credential-osxkeychain erase
-  printf "protocol=https\nhost=github.com\nusername=%s\npassword=%s\n" \
-        "$STRAP_GITHUB_USER" "$STRAP_GITHUB_TOKEN" \
-        | git credential-osxkeychain store
+
+  if [ -n "$STRAP_GITHUB_USER" ] && [ -n "$STRAP_GITHUB_TOKEN" ]
+  then
+    printf "protocol=https\nhost=github.com\n" | git credential-osxkeychain erase
+    printf "protocol=https\nhost=github.com\nusername=%s\npassword=%s\n" \
+          "$STRAP_GITHUB_USER" "$STRAP_GITHUB_TOKEN" \
+          | git credential-osxkeychain store
+  fi
 fi
 logk
 


### PR DESCRIPTION
At some point (perhaps always) Apple began setting the credential helper in their Git as part of the Xcode Command Line Tools. This is great but it breaks our check so never ends up setting the global git configuration for future, non-Apple Gits. Instead ensure that it’s always set.