### PR TITLE
fix broken Travis CI urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Alternatively, to deploy to [Heroku](https://www.heroku.com) click:
 ## Status
 Stable and in active development.
 
-[![Build Status](https://travis-ci.org/mikemcquaid/strap.svg)](https://travis-ci.org/mikemcquaid/strap)
+[![Build Status](https://travis-ci.org/MikeMcQuaid/strap.svg)](https://travis-ci.org/MikeMcQuaid/strap)
 
 ## Contact
 [Mike McQuaid](mailto:mike@mikemcquaid.com)


### PR DESCRIPTION
Looks like the Travis CI badge and link to the project were broken, since the URL is case sensitive. This PR fixes those links to restore the shiny green badge. ✨ 