### PR TITLE
Remove port 80/443 to 8080/8443 forwarding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Strap is a script to bootstrap a minimal OS X development system. This does not 
 - Installs [Homebrew Bundle](https://github.com/Homebrew/homebrew-bundle) (for `bundler`-like `Brewfile` support)
 - Installs [Homebrew Services](https://github.com/Homebrew/homebrew-services) (for managing Homebrew-installed services)
 - Installs [Homebrew Cask](https://github.com/caskroom/homebrew-cask) (for installing graphical software)
-- Forwards `localhost` port `80` to `8080` and `443` to `8443` (for running web servers as an unprivileged user)
 - Installs the latest OS X software updates (for better security)
 - Installs software from a user's `Brewfile` in their `https://github.com/username/homebrew-brewfile` repository or `.Brewfile` in their home directory.
 - A simple web application to set Git's name, email and GitHub token


### PR DESCRIPTION
This used `pf` rules but, in practice, has unfortunately proved far too unreliable to depend on. Instead GitHub is going to lean into using `launch_socket_server` in Homebrew with the default plist installed as of https://github.com/Homebrew/homebrew-core/pull/2773 (version `1.0.0_1`) to provide the proxying.