### PR TITLE
Remove osx10.11 image name as it's no longer supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: objective-c
 os: osx
 env: OSX=10.11
-osx_image: osx10.11
+osx_image: xcode7.3
 rvm: 2.1.7
 
 install:


### PR DESCRIPTION
The `osx_image: osx10.11` image name was not meant to be a long term supported thing, we've transition to just `xcodeX.x` based names, see https://docs.travis-ci.com/user/languages/objective-c/#Supported-Xcode-versions

Any builds on Travis will, unfortunately, fail, as we didn't realize this tag name was in use in the _wild_ anymore, until you merge in this change.

Thanks for understanding.