### PR TITLE
Fetch user dotfiles from GitHub.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Strap is a script to bootstrap a minimal OS X development system. This does not 
 - Installs [Homebrew Services](https://github.com/Homebrew/homebrew-services) (for managing Homebrew-installed services)
 - Installs [Homebrew Cask](https://github.com/caskroom/homebrew-cask) (for installing graphical software)
 - Installs the latest OS X software updates (for better security)
+- Installs dotfiles from a user's `https://github.com/username/dotfiles` repository and runs `script/setup` to configure them.
 - Installs software from a user's `Brewfile` in their `https://github.com/username/homebrew-brewfile` repository or `.Brewfile` in their home directory.
 - A simple web application to set Git's name, email and GitHub token
 - Mostly idempotent (the slow bit is rerunning `brew update`)

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -247,18 +247,39 @@ else
   logk
 fi
 
+# Setup dotfiles
 if [ -n "$STRAP_GITHUB_USER" ]; then
-  REPO_URL="https://github.com/$STRAP_GITHUB_USER/homebrew-brewfile"
-  REPO_API_URL="https://api.github.com/repos/$STRAP_GITHUB_USER/homebrew-brewfile"
-  STATUS_CODE=$(curl -u "$STRAP_GITHUB_USER:$STRAP_GITHUB_TOKEN" --silent --write-out "%{http_code}" --output /dev/null $REPO_API_URL/contents/Brewfile)
+  STRAP_DOTFILES_SETUP="script/setup"
+
+  DOTFILES_URL="https://github.com/$STRAP_GITHUB_USER/dotfiles"
+  DOTFILES_API_URL="https://api.github.com/repos/$STRAP_GITHUB_USER/dotfiles"
+  STATUS_CODE=$(curl -u "$STRAP_GITHUB_USER:$STRAP_GITHUB_TOKEN" --silent --write-out "%{http_code}" --output /dev/null "$DOTFILES_API_URL/contents/$STRAP_DOTFILES_SETUP")
 
   if [ "$STATUS_CODE" -eq 200 ]; then
-    logn "Fetching user Brewfile from GitHub:"
+    logn "Fetching $STRAP_GITHUB_USER/dotfiles from GitHub:"
+    if [ ! -d "$HOME/.dotfiles" ]; then
+      git clone $Q $DOTFILES_URL ~/.dotfiles
+    fi
+    ~/.dotfiles/"$STRAP_DOTFILES_SETUP"
+    logk
+  fi
+fi
+
+# Setup Brewfile
+if [ -n "$STRAP_GITHUB_USER" ] && ! [ -f "$HOME/.Brewfile" ]; then
+  BREWFILE_URL="https://github.com/$STRAP_GITHUB_USER/homebrew-brewfile"
+  BREWFILE_API_URL="https://api.github.com/repos/$STRAP_GITHUB_USER/homebrew-brewfile"
+  STATUS_CODE=$(curl -u "$STRAP_GITHUB_USER:$STRAP_GITHUB_TOKEN" --silent --write-out "%{http_code}" --output /dev/null "$BREWFILE_API_URL"/contents/Brewfile)
+
+  if [ "$STATUS_CODE" -eq 200 ]; then
+    logn "Fetching $STRAP_GITHUB_USER/homebrew-brewfile from GitHub:"
     if [ ! -d "$HOME/.homebrew-brewfile" ]; then
-      git clone $Q $REPO_URL ~/.homebrew-brewfile
+      git clone $Q $BREWFILE_URL ~/.homebrew-brewfile
     else
-      cd ~/.homebrew-brewfile
-      git pull $Q
+      (
+        cd ~/.homebrew-brewfile
+        git pull $Q
+      )
     fi
     ln -sf ~/.homebrew-brewfile/Brewfile ~/.Brewfile
     logk


### PR DESCRIPTION
If users have a dotfiles repository on GitHub then fetch it and install them locally.

Fixes #40. CC @johndbritton @AlJohri for testing, review and thoughts on the approach, code and docs.