### PR TITLE
Remove homebrew/versions tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Strap is a script to bootstrap a minimal macOS development system. This does not
 - Installs the Xcode Command Line Tools (for compilers and Unix tools)
 - Agree to the Xcode license (for using compilers without prompts)
 - Installs [Homebrew](http://brew.sh) (for installing command-line software)
-- Installs [Homebrew Versions](https://github.com/Homebrew/homebrew-versions) (for installing older versions of command-line software)
 - Installs [Homebrew Bundle](https://github.com/Homebrew/homebrew-bundle) (for `bundler`-like `Brewfile` support)
 - Installs [Homebrew Services](https://github.com/Homebrew/homebrew-services) (for managing Homebrew-installed services)
 - Installs [Homebrew Cask](https://github.com/caskroom/homebrew-cask) (for installing graphical software)

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -239,13 +239,12 @@ log "Updating Homebrew:"
 brew update
 logk
 
-# Install Homebrew Bundle, Cask, Services and Versions tap.
+# Install Homebrew Bundle, Cask and Services tap.
 log "Installing Homebrew taps and extensions:"
 brew bundle --file=- <<EOF
 tap 'caskroom/cask'
 tap 'homebrew/core'
 tap 'homebrew/services'
-tap 'homebrew/versions'
 EOF
 logk
 


### PR DESCRIPTION
It has been deprecated for a while and the migration to `homebrew/core` is now complete.