### PR TITLE
travis.yml: use .ruby-version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os: osx
 osx_image: xcode8.1
-rvm: 2.3.1
 
 install:
   - ./script/bootstrap


### PR DESCRIPTION
This avoids having to hardcode this version in another place.