### PR TITLE
Tweak HOMEBREW_PREFIX chown behaviour

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -200,7 +200,10 @@ logn "Installing Homebrew:"
 HOMEBREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
 [ -n "$HOMEBREW_PREFIX" ] || HOMEBREW_PREFIX="/usr/local"
 [ -d "$HOMEBREW_PREFIX" ] || sudo mkdir -p "$HOMEBREW_PREFIX"
-sudo chown "root:wheel" "$HOMEBREW_PREFIX"
+if [ "$HOMEBREW_PREFIX" = "/usr/local" ]
+then
+  sudo chown "root:wheel" "$HOMEBREW_PREFIX" 2>/dev/null || true
+fi
 (
   cd "$HOMEBREW_PREFIX"
   sudo mkdir -p               Cellar Frameworks bin etc include lib opt sbin share var


### PR DESCRIPTION
- only try to `chown` `/usr/local` as the `root` user (not random Homebrew prefixes).
- allow this `chown` to fail on e.g. Sierra and above where even `root` doesn't have permissions sometimes to modify `/usr/local`'s permissions.