### PR TITLE
Add --cached-credentials flag

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -13,8 +13,8 @@ if [ "$1" = "--sudo-wait" ]; then
   exit 0
 fi
 
-[ "$1" = "--debug" -o "$2" = "--debug" ] && STRAP_DEBUG="1"
-[ "$1" = "--cached-credentials" -o "$2" = "--cached-credentials" ] && STRAP_CACHED_CREDENTIALS="1"
+( [ "$1" = "--debug" ] || [ "$2" = "--debug" ] ) && STRAP_DEBUG="1"
+( [ "$1" = "--cached-credentials" ] || [ "$2" = "--cached-credentials" ] ) && STRAP_CACHED_CREDENTIALS="1"
 STRAP_SUCCESS=""
 
 cleanup() {

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#/ Usage: bin/strap.sh [--debug]
+#/ Usage: bin/strap.sh [--debug] [--cached-credentials]
 #/ Install development dependencies on macOS.
 set -e
 
@@ -13,7 +13,8 @@ if [ "$1" = "--sudo-wait" ]; then
   exit 0
 fi
 
-[ "$1" = "--debug" ] && STRAP_DEBUG="1"
+[ "$1" = "--debug" -o "$2" = "--debug" ] && STRAP_DEBUG="1"
+[ "$1" = "--cached-credentials" -o "$2" = "--cached-credentials" ] && STRAP_CACHED_CREDENTIALS="1"
 STRAP_SUCCESS=""
 
 cleanup() {
@@ -21,7 +22,9 @@ cleanup() {
   if [ -n "$STRAP_SUDO_WAIT_PID" ]; then
     sudo kill "$STRAP_SUDO_WAIT_PID"
   fi
-  sudo -k
+  if [ -z "$STRAP_CACHED_CREDENTIALS" ]; then
+    sudo -k
+  fi
   rm -f "$CLT_PLACEHOLDER"
   if [ -z "$STRAP_SUCCESS" ]; then
     if [ -n "$STRAP_STEP" ]; then
@@ -71,8 +74,10 @@ sw_vers -productVersion | grep $Q -E "^10.(9|10|11|12|13)" || {
 groups | grep $Q admin || abort "Add $USER to the admin group."
 
 # Initialise sudo now to save prompting later.
-log "Enter your password (for sudo access):"
-sudo -k
+if [ -z "$STRAP_CACHED_CREDENTIALS" ]; then
+  log "Enter your password (for sudo access):"
+  sudo -k
+fi
 sudo /usr/bin/true
 [ -f "$STRAP_FULL_PATH" ]
 sudo bash "$STRAP_FULL_PATH" --sudo-wait &


### PR DESCRIPTION
Option allowing Strap to be run with cached sudo credentials if applicable. Allows Strap to be called from other scripts which already have sudo privileges without requiring multiple password entries. Behavior is disabled by default.

Usage: **bash bin/strap.sh --cached-credentials**

Currently, Strap clears all sudo credentials with "sudo -k" before and after running. This is an extremely sensible default which prevents users from accidentally running the script. However, it makes running strap.sh inside another script (which already has sudo privileges) annoying as it results in multiple password prompts for the user.

This flag addresses the multiple password prompt issue but keeps credential caching as an opt in feature so general users will not be effected by default. Generally, this option would only be passed inside another script, which has already been granted sudo privileges.

I'm not sure if this is outside the scope of Strap but it is beneficial for my use case so I figured a pull request couldn't hurt. I did not add any documentation to the README for the new feature as I was not sure how best to incorporate it into the current structure.