### PR TITLE
Improve test for existing Brewfile

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -297,7 +297,7 @@ if [ -n "$STRAP_GITHUB_USER" ]; then
 fi
 
 # Setup Brewfile
-if [ -n "$STRAP_GITHUB_USER" ] && ( [ ! -f "$HOME/.Brewfile" ] || [ "$HOME/.Brewfile" -ef "$HOME/.homebrew-bundle/Brewfile" ] ); then
+if [ -n "$STRAP_GITHUB_USER" ] && ( [ ! -f "$HOME/.Brewfile" ] || [ "$HOME/.Brewfile" -ef "$HOME/.homebrew-brewfile/Brewfile" ] ); then
   HOMEBREW_BREWFILE_URL="https://github.com/$STRAP_GITHUB_USER/homebrew-brewfile"
 
   if git ls-remote "$HOMEBREW_BREWFILE_URL" &>/dev/null; then

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -297,7 +297,7 @@ if [ -n "$STRAP_GITHUB_USER" ]; then
 fi
 
 # Setup Brewfile
-if [ -n "$STRAP_GITHUB_USER" ] && ! [ -f "$HOME/.Brewfile" ]; then
+if [ -n "$STRAP_GITHUB_USER" ] && ( [ ! -f "$HOME/.Brewfile" ] || [ "$HOME/.Brewfile" -ef "$HOME/.homebrew-bundle/Brewfile" ] ); then
   HOMEBREW_BREWFILE_URL="https://github.com/$STRAP_GITHUB_USER/homebrew-brewfile"
 
   if git ls-remote "$HOMEBREW_BREWFILE_URL" &>/dev/null; then


### PR DESCRIPTION
If you re-ran strap it would never update the Brewfile repo because the test for an existing Brewfile `! [ -f "$HOME/.Brewfile" ]` would always catch the symlink that is created on the first run. In bash `-f` tests for _regular files_ which includes symlinks.

This patch improves that set of conditions to include those where strap has already created a symlink.

I've tested this locally and it works great and my repo now gets a pull before strap runs `brew bundle`