### PR TITLE
Dotfiles: do not consider setup/bootstrap failures fatal

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -283,7 +283,9 @@ if [ -n "$STRAP_GITHUB_USER" ]; then
       for i in script/setup script/bootstrap; do
         if [ -f "$i" ] && [ -x "$i" ]; then
           log "Running dotfiles $i:"
-          "$i" 2>/dev/null
+          "$i" 2>/dev/null || {
+            log "Warning - running dotfiles $i failed"
+          }
           break
         fi
       done


### PR DESCRIPTION
This fixes an issue @no-itsbackpack ran into where `script/bootstrap` failing in dotfiles caused strap as a whole to fail. Since cloning down dotfiles is optional, it feels appropriate to log and move on here.