### PR TITLE
Store a lot less on the session to avoid hitting 4k limit for some user profiles

### DIFF
--- a/web/app.rb
+++ b/web/app.rb
@@ -22,7 +22,12 @@ use OmniAuth::Builder do
 end
 
 get "/auth/github/callback" do
-  session[:auth] = request.env["omniauth.auth"]
+  auth = request.env["omniauth.auth"]
+  session[:auth] = {
+    'info' => auth["info"],
+    'credentials' => auth["credentials"]
+  }
+
   return_to = session.delete :return_to
   return_to = "/" if !return_to || return_to.empty?
   redirect to return_to


### PR DESCRIPTION
I've been seeing errors like this when `/auth/github/callback`:

```
2018-07-11T16:48:04.574786+00:00 app[web.1]: Warning! Rack::Session::Cookie data size exceeds 4K.
2018-07-11T16:48:04.574857+00:00 app[web.1]: Warning! Rack::Session::Cookie failed to save session. Content dropped.
```

That means that auth is never saved, so I'm never able to be authenticated, and thus get tokens.

There is a lot of information that comes from omniauth. In practice,
strap only uses:

- email
- nickname
- name
- token

Nothing from the 'extra' key is used, so we can create a new hash that
just has 'info' and 'credentials'