### PR TITLE
Allow users to provide multiple parameters to CUSTOM_HOMEBREW_TAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Instead, to deploy to [Heroku](https://www.heroku.com) click:
 - `WEB_CONCURRENCY`: the number of Unicorn (web server) processes to run (defaults to 3).
 - `STRAP_ISSUES_URL`: the URL where users should file issues (defaults to https://github.com/MikeMcQuaid/strap/issues/new).
 - `STRAP_BEFORE_INSTALL`: instructions displayed in the web application for users to follow before installing Strap (wrapped in `<li>` tags).
-- `CUSTOM_HOMEBREW_TAP`: an optional Homebrew tap to install with `brew tap`.
+- `CUSTOM_HOMEBREW_TAP`: an optional Homebrew tap to install with `brew tap`. Specify multiple arguments to brew tap by separating values with spaces.
 - `CUSTOM_BREW_COMMAND`: a single `brew` command that is run after all other stages have completed.
 
 ## Status

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -325,8 +325,9 @@ fi
 
 # Tap a custom Homebrew tap
 if [ -n "$CUSTOM_HOMEBREW_TAP" ]; then
-  log "Tapping $CUSTOM_HOMEBREW_TAP Homebrew tap:"
-  brew tap "$CUSTOM_HOMEBREW_TAP"
+  read -ra CUSTOM_HOMEBREW_TAP <<< "$CUSTOM_HOMEBREW_TAP"
+  log "Running 'brew tap ${CUSTOM_HOMEBREW_TAP[*]}':"
+  brew tap "${CUSTOM_HOMEBREW_TAP[@]}"
   logk
 fi
 


### PR DESCRIPTION
`brew tap` supports providing an optional repo URL that allows users to specify a tap repository with a custom address.

By allowing strap users to provide multiple parameters to `CUSTOM_HOMEBREW_TAP` they would be able to execute `CUSTOM_BREW_COMMAND` from a such a repository.