### PR TITLE
Enable running on macOS 10.14

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -73,8 +73,8 @@ escape() {
   echo "${1//\'/\\\'}"
 }
 
-sw_vers -productVersion | grep $Q -E "^10.(9|10|11|12|13)" || {
-  abort "Run Strap on macOS 10.9/10/11/12/13."
+sw_vers -productVersion | grep $Q -E "^10.(9|10|11|12|13|14)" || {
+  abort "Run Strap on macOS 10.9/10/11/12/13/14."
 }
 
 [ "$USER" = "root" ] && abort "Run Strap as yourself, not root."

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -130,13 +130,17 @@ then
                 awk -F"*" '/^ +\*/ {print $2}' | sed 's/^ *//' | tail -n1)
   sudo softwareupdate -i "$CLT_PACKAGE"
   sudo rm -f "$CLT_PLACEHOLDER"
-  if [ -n "$STRAP_INTERACTIVE" ]; then
-    echo
-    logn "Requesting user install of Xcode Command Line Tools:"
-    xcode-select --install
-  else
-    echo
-    abort "Run 'xcode-select --install' to install the Xcode Command Line Tools."
+  if ! [ -f "/usr/include/iconv.h" ] || \
+     ! [ -d "/Library/Developer" ]
+  then
+    if [ -n "$STRAP_INTERACTIVE" ]; then
+      echo
+      logn "Requesting user install of Xcode Command Line Tools:"
+      xcode-select --install
+    else
+      echo
+      abort "Run 'xcode-select --install' to install the Xcode Command Line Tools."
+    fi
   fi
   logk
 fi

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -130,15 +130,13 @@ then
                 awk -F"*" '/^ +\*/ {print $2}' | sed 's/^ *//' | tail -n1)
   sudo softwareupdate -i "$CLT_PACKAGE"
   sudo rm -f "$CLT_PLACEHOLDER"
-  if ! [ -f "/usr/include/iconv.h" ]; then
-    if [ -n "$STRAP_INTERACTIVE" ]; then
-      echo
-      logn "Requesting user install of Xcode Command Line Tools:"
-      xcode-select --install
-    else
-      echo
-      abort "Run 'xcode-select --install' to install the Xcode Command Line Tools."
-    fi
+  if [ -n "$STRAP_INTERACTIVE" ]; then
+    echo
+    logn "Requesting user install of Xcode Command Line Tools:"
+    xcode-select --install
+  else
+    echo
+    abort "Run 'xcode-select --install' to install the Xcode Command Line Tools."
   fi
   logk
 fi


### PR DESCRIPTION
Since macOS 10.14 is coming up, this adds support for it. A couple of changes:

1. Explicitly recognize 10.14 as a valid OS.
2. Remove the hardcoded `iconv.h` check, since headers are no longer installed at that location.