### PR TITLE
Improve string escaping for LoginWindowText

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -70,7 +70,7 @@ log()   { STRAP_STEP="$*"; sudo_init; echo "--> $*"; }
 logn()  { STRAP_STEP="$*"; sudo_init; printf -- "--> %s " "$*"; }
 logk()  { STRAP_STEP="";   echo "OK"; }
 escape() {
-  echo "${1//\'/\\\'}"
+  printf '%s' "${1//\'/\'}"
 }
 
 MACOS_VERSION="$(sw_vers -productVersion)"


### PR DESCRIPTION
Addresses #183.

I believe that this should solve the original issue in #152 without showing double-quoted strings on the lock screen.

### Verification
```bash
STRAP_GIT_NAME="My (awes'ome) Nåme"
STRAP_GIT_EMAIL="ñøbo'dy'@t'he(internet).com"

if [ -n "$STRAP_GIT_NAME" ] && [ -n "$STRAP_GIT_EMAIL" ]; then
  sudo defaults write /Library/Preferences/com.apple.loginwindow \
    LoginwindowText \
    "'Found this computer? Please contact $(escape "$STRAP_GIT_NAME") at $(escape "$STRAP_GIT_EMAIL").'"
fi
```

```bash
# Show the lock screen
/System/Library/CoreServices/Menu\ Extras/User.menu/Contents/Resources/CGSession -suspend
```
#### Screenshot
![lwscreenshot 2018-10-31 at 1 04 54 pm](https://user-images.githubusercontent.com/191847/47805417-a6f22300-dd0d-11e8-984a-81874bef7645.png)
