### PR TITLE
azuze-pipelines-yml: early exit on errors.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@ jobs:
     vmImage: macOS-10.13
   steps:
     - bash: |
+        set -e
         ./script/bootstrap
         sudo rm -rf /usr/local/bin/brew /usr/local/.??* /Applications/Xcode.app /Library/Developer/CommandLineTools /usr/local/Caskroom
         sudo pkgutil --forget com.apple.pkg.CLTools_Executables


### PR DESCRIPTION
We don't want to silently ignore failing commands.