### PR TITLE
Avoid machine sleeping whilst running strap

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -81,6 +81,9 @@ echo "$MACOS_VERSION" | grep $Q -E "^10.(9|10|11|12|13|14)" || {
 [ "$USER" = "root" ] && abort "Run Strap as yourself, not root."
 groups | grep $Q admin || abort "Add $USER to the admin group."
 
+# Prevent sleeping during script execution, as long as the machine is on AC power
+caffeinate -s -w $$ &
+
 # Set some basic security settings.
 logn "Configuring security settings:"
 defaults write com.apple.Safari \


### PR DESCRIPTION
This is a simple change to prevent the machine sleeping whilst the strap script is running. Hopefully simple enough to pass the litmus test in #124? It makes use of the macOS built in CLI tool `caffeinate`.

The command I've selected here uses `-i` (prevent system from idle sleeping), `-d` (prevent display from sleeping and `-w` (wait for process with PID to exit - in this case the PID of the bash shell running the script). 

There is an argument for removing `-d` but I prefer to see progress so left it in.