### PR TITLE
Remove quotes around custom brew command

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -352,7 +352,7 @@ fi
 # Run a custom `brew` command
 if [ -n "$CUSTOM_BREW_COMMAND" ]; then
   log "Executing 'brew $CUSTOM_BREW_COMMAND':"
-  brew "$CUSTOM_BREW_COMMAND"
+  brew $CUSTOM_BREW_COMMAND
   logk
 fi
 

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -352,6 +352,7 @@ fi
 # Run a custom `brew` command
 if [ -n "$CUSTOM_BREW_COMMAND" ]; then
   log "Executing 'brew $CUSTOM_BREW_COMMAND':"
+  # shellcheck disable=SC2086
   brew $CUSTOM_BREW_COMMAND
   logk
 fi


### PR DESCRIPTION
The quotes around `$CUSTOM_BREW_COMMAND` caused us issues. i.e.
```
➜  brew "cask install gu-strap"
Error: Unknown command: cask install gu-strap
➜  brew cask install gu-strap
Updating Homebrew...
^C^C
```

Credit to @philmcmahon, just upstreaming.