### PR TITLE
Improve the check for whether the user is in the admin group

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -150,7 +150,7 @@ echo "$MACOS_VERSION" | grep $Q -E "^10.(9|10|11|12|13|14|15)" || {
 }
 
 [ "$USER" = "root" ] && abort "Run Strap as yourself, not root."
-groups | grep $Q admin || abort "Add $USER to the admin group."
+groups | grep $Q -E "\b(admin)\b" || abort "Add $USER to the admin group."
 
 # Prevent sleeping during script execution, as long as the machine is on AC power
 caffeinate -s -w $$ &


### PR DESCRIPTION
Previously this check would also match if the user was part of another group that included the word admin (e.g. _lpadmin). Now limit the check to only look for the whole word 'admin'.