### PR TITLE
Add workflow to requested oauth scopes

### DIFF
--- a/web/app.rb
+++ b/web/app.rb
@@ -18,7 +18,7 @@ CUSTOM_BREW_COMMAND = ENV["CUSTOM_BREW_COMMAND"]
 set :sessions, secret: SESSION_SECRET
 
 use OmniAuth::Builder do
-  options = { scope: "user:email,repo" }
+  options = { scope: "user:email,repo,workflow" }
   options[:provider_ignores_state] = true if ENV["RACK_ENV"] == "development"
   provider :github, GITHUB_KEY, GITHUB_SECRET, options
 end


### PR DESCRIPTION
To edit workflow files using OAuth the `workflow` scope is necessary. This restriction was put in place to prevent nefarious OAuth apps from being able to push workflow files (which could cost users money or compromise secrets).
Developers using `strap` to boostrap their environments will however want the ability to edit workflow files and as such we should request the scope here.