### PR TITLE
Add GPR support to GITHUB_TOKEN

### DIFF
--- a/web/app.rb
+++ b/web/app.rb
@@ -18,7 +18,7 @@ CUSTOM_BREW_COMMAND = ENV["CUSTOM_BREW_COMMAND"]
 set :sessions, secret: SESSION_SECRET
 
 use OmniAuth::Builder do
-  options = { scope: "user:email,repo,workflow" }
+  options = { scope: "user:email,repo,workflow,write:packages,read:packages" }
   options[:provider_ignores_state] = true if ENV["RACK_ENV"] == "development"
   provider :github, GITHUB_KEY, GITHUB_SECRET, options
 end


### PR DESCRIPTION
There is a request to be able to use strap's token to login to GitHub Package Registry.