### PR TITLE
workflows/tests: remove Big Sur workaround.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,6 @@ jobs:
     - run: brew test-bot --only-cleanup-before
 
     - run: brew doctor
-      env:
-        HOMEBREW_GITHUB_ACTIONS_BIG_SUR_TESTING: 1 # TODO: remove when Big Sur is released.
 
     - run: brew install --build-from-source libfaketime
 


### PR DESCRIPTION
No longer required as-of https://github.com/Homebrew/brew/pull/9189.