### PR TITLE
Revert "Use POST for OmniAuth."

### DIFF
--- a/web/app.rb
+++ b/web/app.rb
@@ -17,7 +17,6 @@ CUSTOM_BREW_COMMAND = ENV["CUSTOM_BREW_COMMAND"]
 
 set :sessions, secret: SESSION_SECRET
 
-OmniAuth.config.allowed_request_methods = [:post]
 use OmniAuth::Builder do
   # access is given for gh cli, packages, git client setup and repo checkouts
   options = { scope: "user:email, repo, workflow, write:packages, read:packages, read:org, read:discussions" }


### PR DESCRIPTION
The app itself doesn't actually `POST` to the omniauth checkpoint, so attempting to fetch `strap.sh` just falls back on the debug response that prints the route that was being fetched.