### PR TITLE
Handle `brew cask install` deprecation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,52 +7,52 @@ jobs:
   tests:
     runs-on: macOS-11.0
     steps:
-    - name: Set up Git repository
-      uses: actions/checkout@main
+      - name: Set up Git repository
+        uses: actions/checkout@main
 
-    - run: brew test-bot --only-cleanup-before
+      - run: brew test-bot --only-cleanup-before
 
-    - name: Cleanup macOS
-      run: |
-        sudo rm -rf /usr/local/bin/brew /usr/local/.??* \
-                    /usr/local/Homebrew \
-                    /Applications/Xcode.app /usr/local/Caskroom \
-                    /Library/Developer/CommandLineTools
+      - name: Cleanup macOS
+        run: |
+          sudo rm -rf /usr/local/bin/brew /usr/local/.??* \
+                      /usr/local/Homebrew \
+                      /Applications/Xcode.app /usr/local/Caskroom \
+                      /Library/Developer/CommandLineTools
 
-    - name: Use newer Xcode
-      run: sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
+      - name: Use newer Xcode
+        run: sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
 
-    - run: bin/strap.sh
-      env:
-        STRAP_CI: 1
-        STRAP_DEBUG: 1
+      - run: bin/strap.sh
+        env:
+          STRAP_CI: 1
+          STRAP_DEBUG: 1
 
-    - run: brew config
+      - run: brew config
 
-    - run: brew doctor
+      - run: brew doctor
 
-    - name: Get Ruby version
-      run: echo "::set-output name=RUBY_VERSION::$(cat .ruby-version)"
-      id: ruby_version
+      - name: Get Ruby version
+        run: echo "::set-output name=RUBY_VERSION::$(cat .ruby-version)"
+        id: ruby_version
 
-    - name: Set up Ruby
-      uses: actions/setup-ruby@main
-      with:
-        ruby-version: "${{ steps.ruby_version.outputs.RUBY_VERSION }}"
+      - name: Set up Ruby
+        uses: actions/setup-ruby@main
+        with:
+          ruby-version: "${{ steps.ruby_version.outputs.RUBY_VERSION }}"
 
-    - name: Install Ruby dependencies
-      run: brew install gmp openssl@1.1 libyaml
+      - name: Install Ruby dependencies
+        run: brew install gmp openssl@1.1 libyaml
 
-    - run: script/bootstrap
+      - run: script/bootstrap
 
-    - run: script/cibuild
+      - run: script/cibuild
 
-    - run: brew install --build-from-source libfaketime
+      - run: brew install --build-from-source --formula libfaketime
 
-    - run: brew cask install orka
+      - run: brew install --cask orka
 
-    - run: brew install shellcheck
+      - run: brew install --formula shellcheck
 
-    - run: shellcheck bin/strap.sh
+      - run: shellcheck bin/strap.sh
 
-    - run: bundle exec rubocop
+      - run: bundle exec rubocop

--- a/web/app.rb
+++ b/web/app.rb
@@ -88,8 +88,7 @@ get "/" do
       </li>
       <li>
         Install additional software with
-        <code>brew install</code> and
-        <code>brew cask install</code>.
+        <code>brew install</code>.
       </li>
     </ol>
   HTML


### PR DESCRIPTION
- Let VS Code auto-format the YAML.
- use `brew install --formula` and `brew install --cask` instead. These flags aren't needed but let's use them for explicitness/testing.
- Remove documentation reference to `brew cask install`.