### PR TITLE
Removing cask tap

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -314,7 +314,6 @@ logk
 # Install Homebrew Bundle, Cask and Services tap.
 log "Installing Homebrew taps and extensions:"
 brew bundle --file=- <<RUBY
-tap 'homebrew/cask'
 tap 'homebrew/core'
 tap 'homebrew/services'
 RUBY


### PR DESCRIPTION
As titled, it's no longer required to tap homebrew/cask to install apps from homebrew-casks.