### PR TITLE
strap.sh: handle rerunning Strap.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,12 @@ jobs:
           STRAP_CI: 1
           STRAP_DEBUG: 1
 
+      - name: Rerun bin/strap.sh
+        run: bin/strap.sh
+        env:
+          STRAP_CI: 1
+          STRAP_DEBUG: 1
+
       - run: brew config
 
       - run: brew doctor

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -273,7 +273,8 @@ logk
 # Setup Homebrew directory and permissions.
 logn "Installing Homebrew:"
 HOMEBREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
-if [ -z "$HOMEBREW_PREFIX" ]; then
+HOMEBREW_REPOSITORY="$(brew --repository 2>/dev/null || true)"
+if [ -z "$HOMEBREW_PREFIX" ] || [ -z "$HOMEBREW_REPOSITORY" ]; then
   UNAME_MACHINE="$(/usr/bin/uname -m)"
   if [[ "$UNAME_MACHINE" == "arm64" ]]; then
     HOMEBREW_PREFIX="/opt/homebrew"


### PR DESCRIPTION
When rerunning Strap and Homebrew was already installed the `HOMEBREW_REPOSITORY` could be unset causing failures.

Also, add a CI test to verify this case.