### PR TITLE
bin/strap.sh: make credential handling more generic.

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -254,17 +254,17 @@ fi
 # Setup GitHub HTTPS credentials.
 if git credential-osxkeychain 2>&1 | grep $Q "git.credential-osxkeychain"
 then
-  if [ "$(git config --global credential.helper)" != "osxkeychain" ]
+  if [[ "$(git config --global credential.helper)" != *"osxkeychain"* ]]
   then
     git config --global credential.helper osxkeychain
   fi
 
   if [ -n "$STRAP_GITHUB_USER" ] && [ -n "$STRAP_GITHUB_TOKEN" ]
   then
-    printf "protocol=https\\nhost=github.com\\n" | git credential-osxkeychain erase
+    printf "protocol=https\\nhost=github.com\\n" | git credential reject
     printf "protocol=https\\nhost=github.com\\nusername=%s\\npassword=%s\\n" \
           "$STRAP_GITHUB_USER" "$STRAP_GITHUB_TOKEN" \
-          | git credential-osxkeychain store
+          | git credential approve
   fi
 fi
 logk


### PR DESCRIPTION
This handles e.g. https://github.com/MikeMcQuaid/dotfiles/commit/16bb28608c761293061a03eef666b09ffb611ff7 so that cross-platform credential handling can be done.