### PR TITLE
Make /usr/local/* chowns non-recursive

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -290,8 +290,8 @@ then
 fi
 (
   cd "$HOMEBREW_PREFIX"
-  sudo_askpass mkdir -p               Cellar Frameworks bin etc include lib opt sbin share var
-  sudo_askpass chown "$USER:admin" Cellar Frameworks bin etc include lib opt sbin share var
+  sudo_askpass mkdir -p               Cellar Caskroom Frameworks bin etc include lib opt sbin share var
+  sudo_askpass chown    "$USER:admin" Cellar Caskroom Frameworks bin etc include lib opt sbin share var
 )
 
 [ -d "$HOMEBREW_REPOSITORY" ] || sudo_askpass mkdir -p "$HOMEBREW_REPOSITORY"

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -291,7 +291,7 @@ fi
 (
   cd "$HOMEBREW_PREFIX"
   sudo_askpass mkdir -p               Cellar Frameworks bin etc include lib opt sbin share var
-  sudo_askpass chown -R "$USER:admin" Cellar Frameworks bin etc include lib opt sbin share var
+  sudo_askpass chown "$USER:admin" Cellar Frameworks bin etc include lib opt sbin share var
 )
 
 [ -d "$HOMEBREW_REPOSITORY" ] || sudo_askpass mkdir -p "$HOMEBREW_REPOSITORY"


### PR DESCRIPTION
Certain macOS AV tools that might come pre-installed in an enterprise environment may install themselves into `/usr/local` and may intercept calls to `chown` to avoid having their ownership changed. Unfortunately, this causes the Homebrew install step of strap.sh to fail on such machines with these AV tools installed.

It seems like a recursive chown isn't really necessary in this case, especially since on a fresh machine, the directories would have just been created and not have anything in them yet. Additionally, I don't think the Homebrew installer uses a recursive `chown` for these directories. If there's a case I'm not thinking about here and the recursive `chown` is important, I would maybe advocate for using `-f` instead, to avoid permissions errors from tanking the `chown`