### PR TITLE
workflows/tests: fix ghcr token.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Deploy the Docker image to GitHub Packages and Docker Hub
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{secrets.GHCR_TOKEN}} | \
+          echo ${{secrets.GITHUB_TOKEN}} | \
             docker login ghcr.io -u mikemcquaid --password-stdin
           docker tag strap "ghcr.io/mikemcquaid/strap:master"
           docker push "ghcr.io/mikemcquaid/strap:master"


### PR DESCRIPTION
This can be done with a raw `GITHUB_TOKEN`.