### PR TITLE
strap: better handle TouchID.

### DIFF
--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -74,6 +74,11 @@ sudo_init() {
     return
   fi
 
+  # If TouchID for sudo is setup: use that instead.
+  if grep -q pam_tid /etc/pam.d/sudo; then
+    return
+  fi
+
   local SUDO_PASSWORD SUDO_PASSWORD_SCRIPT
 
   if ! sudo --validate --non-interactive &>/dev/null; then

--- a/script/cibuild
+++ b/script/cibuild
@@ -16,7 +16,7 @@ check_sudo_askpass() {
     # find all sudo
     grep --line-number "[^'\"]sudo " bin/strap.sh |
       # filter out comments
-      grep -Ev "^\d*:#" |
+      grep -Ev "^\d*: *#" |
       # filter out session resets
       grep -v "sudo --reset-timestamp" |
       # filter out password prompt


### PR DESCRIPTION
If `sudo` is setup to use `pam_tid` for TouchID: don't prompt for a password.

Checkout https://github.com/MikeMcQuaid/dotfiles/blob/master/bin/touchid-enable-pam-sudo if you're interested in a script to enable TouchID for `sudo`.