### PR TITLE
Enable `sudo` using TouchID

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Replacing [Boxen](https://github.com/boxen/boxen) in [GitHub](https://github.com
 
 ## Features
 
+- Enables `sudo` using TouchID
 - Disables Java in Safari (for better security)
 - Enables the macOS screensaver password immediately (for better security)
 - Enables the macOS application firewall (for better security)

--- a/bin/strap.sh
+++ b/bin/strap.sh
@@ -145,6 +145,12 @@ logk() {
   echo "OK"
 }
 
+logskip() {
+  STRAP_STEP=""
+  echo "SKIPPED"
+  echo "$*"
+}
+
 escape() {
   printf '%s' "${1//\'/\'}"
 }
@@ -174,6 +180,27 @@ groups | grep $Q -E "\b(admin)\b" || abort "Add $USER to the admin group."
 
 # Prevent sleeping during script execution, as long as the machine is on AC power
 caffeinate -s -w $$ &
+
+# Check and, if necessary, enable sudo authentication using TouchID.
+# Don't care about non-alphanumeric filenames when doing a specific match
+# shellcheck disable=SC2010
+if ls /usr/lib/pam | grep $Q "pam_tid.so"; then
+  logn "Configuring sudo authentication using TouchID:"
+  PAM_FILE="/etc/pam.d/sudo"
+  FIRST_LINE="# sudo: auth account password session"
+  if grep $Q pam_tid.so "$PAM_FILE"; then
+    logk
+  elif ! head -n1 "$PAM_FILE" | grep $Q "$FIRST_LINE"; then
+    logskip "$PAM_FILE is not in the expected format!"
+  else
+    TOUCHID_LINE="auth       sufficient     pam_tid.so"
+    sudo_askpass sed -i .bak -e \
+      "s/$FIRST_LINE/$FIRST_LINE\n$TOUCHID_LINE/" \
+      "$PAM_FILE"
+    sudo_askpass rm "$PAM_FILE.bak"
+    logk
+  fi
+fi
 
 # Set some basic security settings.
 logn "Configuring security settings:"

--- a/script/style
+++ b/script/style
@@ -42,6 +42,9 @@ sudo_askpass_style() {
       # accept sudo passthrough without askpass
       grep -v 'sudo "$@"' \
       |
+      # accept sudo log message
+      grep -v 'Configuring sudo authentication using TouchID:' \
+      |
       # filter out check to see if sudo is required
       grep -v "sudo --validate" || true
   )


### PR DESCRIPTION
If the necessary PAM module exists and the configuration file is in the
expected format: enable the TouchID PAM module.