### PR TITLE
Use GitHub Actions Ubuntu 22.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,20 +6,21 @@ on:
   pull_request:
 jobs:
   style:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up Git repository
         uses: actions/checkout@main
 
-      - name: Install shfmt
-        run: |
-          brew update
-          brew install shfmt
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@master
         with:
           bundler-cache: true
+
+      - name: Install shfmt
+        run: brew install shfmt
 
       - run: script/style
 


### PR DESCRIPTION
It has `brew` in the `PATH` for now and use `Homebrew/actions/setup-homebrew` to handle when it does not.