### PR TITLE
workflows/tests: fix Docker Hub default branch reference.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,7 +105,7 @@ jobs:
           docker push ghcr.io/mikemcquaid/strap:latest
 
       - name: Deploy the Docker image to Docker Hub
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{secrets.DOCKER_TOKEN}} | \
             docker login --username=mikemcquaid --password-stdin


### PR DESCRIPTION
Otherwise we don't push to Docker Hub on `main` pushes.