### PR TITLE
Improve GitHub Actions configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,37 @@
 version: 2
+
 updates:
-  - package-ecosystem: bundler
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
       interval: daily
-      time: "08:45"
+      time: "07:15"
       timezone: "Europe/London"
-    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: daily
+      time: "07:30"
+      timezone: "Europe/London"
     allow:
-      - dependency-type: direct
-      - dependency-type: indirect
-    ignore:
-      - dependency-name: omniauth-github
-        versions:
-          - "> 2.0.0, < 3"
+      - dependency-type: all
+    groups:
+      bundler:
+        patterns:
+          - "*"
+
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: daily
-      time: "08:45"
+      time: "08:00"
       timezone: "Europe/London"
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
 
       - name: Set up CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
 
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@master
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
 
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-12
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
 
       - name: Set up Homebrew to install from API
         run: echo HOMEBREW_NO_INSTALL_FROM_API= >> "$GITHUB_ENV"
@@ -65,7 +65,7 @@ jobs:
         run: brew install gmp openssl@1.1 libyaml
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@master
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
 
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
 
       - name: Build and tag Docker image
         run: |


### PR DESCRIPTION
- Get Dependabot to check for GitHub Actions updates
- Check for Dependabot updates at different times
- Group Dependabot updates where possible
- Switch GitHub Actions to use tags where possible