### PR TITLE
Cleanup workflows and scripts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,16 +36,16 @@ jobs:
       - run: brew test-bot --only-cleanup-before
 
       - name: Cleanup macOS
-        run: |
-          sudo rm -rf /usr/local/bin/brew /usr/local/.??* \
-                      /usr/local/Homebrew \
-                      /Applications/Xcode.app /usr/local/Caskroom \
-                      /Library/Developer/CommandLineTools
+        run: sudo rm -rf /usr/local/bin/brew /usr/local/.??*
+                         /usr/local/Homebrew
+                         /Applications/Xcode.app /usr/local/Caskroom
+                         /Library/Developer/CommandLineTools
+
+      - name: Check installed Xcodes
+        run: ls /Applications/Xcode*.app
 
       - name: Use newer Xcode
-        run: |
-          ls /Applications/Xcode*.app
-          sudo xcode-select --switch /Applications/Xcode_13.3.1.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_13.3.1.app/Contents/Developer
 
       - run: bin/strap.sh
         env:
@@ -87,6 +87,8 @@ jobs:
 
       - name: Build and tag Docker image
         run: |
+          set -euo pipefail
+
           docker build --build-arg RUBY_VERSION=$(cat .ruby-version) --tag strap .
           docker tag strap mikemcquaid/strap:master
           docker tag strap mikemcquaid/strap:main
@@ -98,6 +100,8 @@ jobs:
       - name: Deploy the Docker image to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
+          set -euo pipefail
+
           echo ${{secrets.GITHUB_TOKEN}} | \
             docker login --username=mikemcquaid --password-stdin ghcr.io
           docker push ghcr.io/mikemcquaid/strap:master
@@ -107,6 +111,8 @@ jobs:
       - name: Deploy the Docker image to Docker Hub
         if: github.ref == 'refs/heads/main'
         run: |
+          set -euo pipefail
+
           echo ${{secrets.DOCKER_TOKEN}} | \
             docker login --username=mikemcquaid --password-stdin
           docker push mikemcquaid/strap:master

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+
 cd "$(dirname "$0")/.."
 
 (command -v bundle >/dev/null 2>&1 && bundle -v >/dev/null 2>&1) || {

--- a/script/server
+++ b/script/server
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+
 cd "$(dirname "$0")/.."
 
 export PORT="${PORT:-3000}"

--- a/script/style
+++ b/script/style
@@ -1,8 +1,9 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+
 cd "$(dirname "$0")/.."
 
-[[ $1 == "--fix" ]] && STYLE_FIX="1"
+[[ ${1-} == "--fix" ]] && STYLE_FIX="1"
 
 # assert that any reference of sudo uses --askpass (or is whitelisted for another reason)
 sudo_askpass_style() {
@@ -56,7 +57,7 @@ ruby_version_style() {
 shell_style() {
   local shfmt_args="--indent 2 --simplify --language-dialect=bash"
 
-  if [[ -n ${STYLE_FIX} ]]; then
+  if [[ -n ${STYLE_FIX-} ]]; then
     for file in "$@"; do
       # Want to expand shfmt_args
       # shellcheck disable=SC2086
@@ -73,11 +74,11 @@ shell_style() {
 }
 
 ruby_style() {
-  if [[ -n ${STYLE_FIX} ]]; then
+  if [[ -n ${STYLE_FIX-} ]]; then
     local rubocop_args="--autocorrect-all"
   fi
 
-  bundle exec rubocop --format quiet ${rubocop_args}
+  bundle exec rubocop --format quiet ${rubocop_args-}
 }
 
 script/bootstrap

--- a/script/tests
+++ b/script/tests
@@ -1,10 +1,10 @@
 #!/bin/bash
-set -e
+set -xeuo pipefail
 cd "$(dirname "$0")/.."
 
 tests_cleanup() {
-  if [ -n "$SERVER_PID" ]; then
-    kill "$SERVER_PID"
+  if [[ -n ${SERVER_PID-} ]]; then
+    kill "${SERVER_PID}"
   fi
 }
 


### PR DESCRIPTION
- avoid `run: |` in GitHub Actions where possible
- use `set -euo pipefail` more often in GitHub Actions and scripts
- use `set -x` too in `script/tests` to make failures more obvious