### PR TITLE
web/views/root: note Workbrew.

### DIFF
--- a/web/views/root.erb
+++ b/web/views/root.erb
@@ -18,12 +18,24 @@
       </p>
       <%= @text %>
       <p class="lead">
-        I maintain 👢 Strap in my spare time and no longer work at GitHub.
-        Please
-        <a href="https://github.com/sponsors/MikeMcQuaid">
-          sponsor me on GitHub Sponsors
-        </a>
-        , thanks ❤️!</p>
+        If you like Strap, you'll love
+        <a href="https://workbrew.com">
+          ☕️ Workbrew
+        </a>.
+      </p>
+      <p>
+        In 2023 I started a company, Workbrew, to provide the missing features and support for companies using Homebrew.
+        <br>
+        Workbrew is now available in private beta.
+        <br>
+        It provides MDM integration, fleet configuration and remote <code>brew</code> command execution.
+        <br>
+        All our customers get hands-on bespoke support from the longest-running Homebrew maintainer (me,
+        <a href="https://mikemcquaid.com">Mike McQuaid</a>!).
+        <br>
+        Please <a href="https://workbrew.com/contact">get in touch</a> or
+        <a href="https://workbrew.com/demo">book a demo</a>.
+      </p>
     </div>
 
     <a href="https://github.com/MikeMcQuaid/strap">


### PR DESCRIPTION
The sponsorship drive has been a dismal failure so point people to Workbrew instead (as it's at the stage that people may actually find it interesting and useful).